### PR TITLE
Qr fetch remote fix

### DIFF
--- a/kvass.go
+++ b/kvass.go
@@ -275,6 +275,8 @@ func main() {
 		WithAction(func(args []string, options map[string]string) int {
 			key := args[0]
 			p := getPersistance(options)
+			defer p.Close()
+
 			entry, err := p.GetEntry(key)
 			if err != nil {
 				panic(err)

--- a/kvass.go
+++ b/kvass.go
@@ -277,6 +277,10 @@ func main() {
 			p := getPersistance(options)
 			defer p.Close()
 
+			err := p.GetRemoteUpdates()
+			if err != nil {
+				logger.Println("Couldn't get updates from server. ", err)
+			}
 			entry, err := p.GetEntry(key)
 			if err != nil {
 				panic(err)


### PR DESCRIPTION
When attempting to generate a QR code for an entry that hasn't yet been seen on this device but does exist on the server, we get an entry does not exist error.

This fixes that by adding a refresh of server data before the entry is retreived.