### PR TITLE
Add some detail about --bind option in README and CLI printout

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Remote:          	(None)
 $ kvass config key 5abf59f5f1a2f3c998a4f592ce081a23e14a68fd8a792259c6ec0fc1e8fb1246 # set the same key for all your devices
 $ kvass config remote yourserver.com:8000 # tell kvass where to find the server instance
 
-# run "kvass serve" on your server using systemd, screen or the init system of your choice. (runit, anyone?)
+# Run "kvass serve" on your server using systemd, screen or the init system of your choice (runit, anyone?). You can specify the interface and port to host at with [--bind].
+
+$ kvass serve --bind="0.0.0.0:80" # host on the default HTTP port (which means you can generate cleaner URLs - just set your remote no port)
 
 # every set will now be broadcasted to the server
 $ kvass set "hello from the other side" hello
@@ -70,7 +72,7 @@ Sub-commands:
     kvass url      show shareable url of an entry
     kvass qr       print shareable qr code of entry to console
     kvass config   set config parameters
-    kvass serve    start in server mode
+    kvass serve    start in server mode [--bind="ip:port" (default: 0.0.0.0:8000)]
 ```
 
 # Installation
@@ -170,7 +172,7 @@ count=0                                       count = 1               count incr
 The merging of states is actually trivial now:
 ```go
 func (s *SqlitePersistance) UpdateOn(entry KvEntry) error {
-	
+
     oldEntry := getCurrentEntryFromDB(entry.Key)
 
     // update the remote counter

--- a/kvass.go
+++ b/kvass.go
@@ -144,7 +144,7 @@ func main() {
 			return 0
 		})
 
-	serve := cli.NewCommand("serve", "start in server mode").
+	serve := cli.NewCommand("serve", "start in server mode [--bind=\"ip:port\" (default: 0.0.0.0:8000)]").
 		WithOption(cli.NewOption("bind", "bind address (default: \"0.0.0.0:8000\" meaning all interfaces, port 8000)")).
 		WithAction(func(args []string, options map[string]string) int {
 			bind, contains := options["bind"]


### PR DESCRIPTION
I was happy to find out about the `--bind` option when reading over the code, but could not really find it documented anywhere.

Tried to incorporate it into the CLI "help printout" in a better way but had no luck - seems it doesn't have support for e.g. printing a command-specific option alongside the command.

May be worth adding the binding setting to kvass config and set it once via `kvass config bind 1.2.3.4:56`. Documenting that via CLI would go a bit better then, I think.

Please feel free to ignore this PR or change things about it if you want to!

This is a great little tool.