### PR TITLE
Fixed Pushing without server connection

### DIFF
--- a/src/model.go
+++ b/src/model.go
@@ -17,6 +17,7 @@ type KvEntry struct {
 	TimestampUnixMicro int64
 	ProcessID          uint32 // randomly chosen for each node
 	Counter            uint64 // lamport clock
+	NeedsToBePushed    bool
 }
 
 func (e KvEntry) isGreaterOrEqualThan(other KvEntry) bool {
@@ -83,6 +84,7 @@ func Set(p *SqlitePersistance, key string, value []byte) error {
 		Value:              value,
 		Counter:            count,
 		UrlToken:           base64.RawURLEncoding.EncodeToString(url_bytes),
+		NeedsToBePushed:    true,
 	})
 	return err
 

--- a/src/sync_test.go
+++ b/src/sync_test.go
@@ -1,0 +1,45 @@
+package kvass
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestPush(t *testing.T) {
+	// create two instances client and remote, set a key on the client,
+	// apply its updates on the remote and check if the remote also set the
+	// key.
+	t.Parallel()
+	fail := func(err error) {
+		if err != nil {
+			t.Error(err)
+		}
+	}
+	client, err := NewSqlitePersistance(":memory:")
+	defer client.Close()
+	fail(err)
+
+	remote, err := NewSqlitePersistance(":memory:")
+	fail(err)
+	defer remote.Close()
+
+	Set(client, "foo", []byte("bar"))
+
+	updates, err := client.GetUpdates(UpdateRequest{
+		Counter:   client.State.RemoteCounter,
+		ProcessID: ReservedProcessID,
+	})
+	fail(err)
+
+	for _, update := range updates {
+		fail(remote.UpdateOn(update))
+	}
+
+	entry, err := remote.GetEntry("foo")
+	fail(err)
+
+	if !bytes.Equal(entry.Value, []byte("bar")) {
+		t.Error("Remote did not get the correct value.")
+	}
+
+}


### PR DESCRIPTION
It marks entries that could not yet be sent to the remote. Prior, keys set with the server unreachable would not be sent until they were set again.

As the integration tests are somewhat lacking at the moment, it would be appreciated if anyone tries out if this fix works for 
them,