### PR TITLE
make remote host a real url

### DIFF
--- a/src/sqlite_persistance.go
+++ b/src/sqlite_persistance.go
@@ -50,7 +50,10 @@ func (p *SqlitePersistance) GetRemoteUpdates() (err error) {
 		return err
 	}
 
-	pull, _ := p.State.RemoteURL.Parse("pull") // this should never fail
+	pull, err := p.State.RemoteURL.Parse("pull")
+	if err != nil {
+		panic(err)
+	}
 	resp, err := http.Post(pull.String(), "application/json", bytes.NewReader(request))
 	if err != nil {
 		return err
@@ -99,7 +102,10 @@ func (p *SqlitePersistance) Push() error {
 		panic(err)
 	}
 
-	push, _ := p.State.RemoteURL.Parse("push") // this should never fail
+	push, err := p.State.RemoteURL.Parse("push")
+	if err != nil {
+		panic(err)
+	}
 	resp, err := http.DefaultClient.Post(push.String(), "application/json", bytes.NewReader(payload))
 	if err != nil || resp.StatusCode != 200 {
 		return fmt.Errorf("Error posting update to server: %v", err)


### PR DESCRIPTION
this means you can do things like prefix-based reverse-proxying and reverse-proxying in general, actually
it also knows about proxying to subfolders and thus uses a url-base, meaning you can do something like `kvass config remote https://my.normal.website/secret/kvass/`

example setup with caddy
server: `kvass --bind=localhost:8081` (you can also bind to 0.0.0.0 if the reverse proxy is off-system)
proxy:
```caddyfile
my.domain {
	// ... the rest of the domain
	handle_path /secret/prefix/kvass/* {
		reverse_proxy http://localhost:8081 # match to above
	}
}
```
clients: `kvass config key ... && kvass config remote https://my.domain/secret/prefix/kvass/`

Note that the trailing `/` is important.